### PR TITLE
Update project version and add implicit conversions

### DIFF
--- a/Src/Result.Api/BaseApiResult/ApiResult.cs
+++ b/Src/Result.Api/BaseApiResult/ApiResult.cs
@@ -19,4 +19,16 @@ public class ApiResult<TSuccess> : ApiResult<TSuccess, string>
     {
         return new ApiResult<TSuccess>(false, null, error, statusCode);
     }
+    
+    public static implicit operator string(ApiResult<TSuccess> result)
+        => result.ErrorModel!;
+
+    public static implicit operator TSuccess(ApiResult<TSuccess> result)
+        => result.SuccessModel!;
+    
+    public static implicit operator ApiResult<TSuccess>(string error)
+        => ApiResult<TSuccess>.Fail(error);
+    
+    public static implicit operator ApiResult<TSuccess>(TSuccess successModel)
+        => ApiResult<TSuccess>.Success(successModel);
 }

--- a/Src/Result.Api/EmptyApiResult/ApiResult.cs
+++ b/Src/Result.Api/EmptyApiResult/ApiResult.cs
@@ -31,6 +31,12 @@ public class ApiResult : Result
             StatusCode = StatusCode
         };
     }
+    
+    public static implicit operator string(ApiResult result)
+        => result.ErrorMessage;
+    
+    public static implicit operator ApiResult(string error)
+        => Fail(StatusCodes.Status400BadRequest, error);
 
     public IResult GetResult()
     {

--- a/Src/Result.Api/Result.Api.csproj
+++ b/Src/Result.Api/Result.Api.csproj
@@ -13,7 +13,7 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/keyroll-99/Result/tree/master</PackageProjectUrl>
         <RepositoryUrl>https://github.com/keyroll-99/Result/tree/master</RepositoryUrl>
-        <PackageTags>Result ErrorOr ApiResult Exception</PackageTags>
+        <PackageTags>Result ApiResult Exception HandleError ResultObject HandlingErrors Errors</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 

--- a/Src/Result.Api/Result.Api.csproj
+++ b/Src/Result.Api/Result.Api.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Version>0.7.1</Version>
+        <Version>0.7.2</Version>
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Result</RootNamespace>
         <PackageId>Keyroll.ApiResult</PackageId>
-        <PackageVersion>0.7.1</PackageVersion>
+        <PackageVersion>0.7.2</PackageVersion>
         <Title>ApiResult</Title>
         <Authors>Karol Kaźmierczak</Authors>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/keyroll-99/Result/tree/master</PackageProjectUrl>
         <RepositoryUrl>https://github.com/keyroll-99/Result/tree/master</RepositoryUrl>
-        <PackageTags>Result ApiResult Exception HandleError ResultObject HandlingErrors Errors</PackageTags>
+        <PackageTags>Result ErrorOr ApiResult Exception</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 


### PR DESCRIPTION
Updated the project version to 0.7.2 in Result.Api.csproj file. Also, implicit conversions are added to the ApiResult classes such that you can now implicitly convert an ApiResult to a string or its success model type, and likewise from a string or success model type to an ApiResult. This facilitates simpler and more intuitive usage of the ApiResult classes.