### PR TITLE
Update version and improve error handling

### DIFF
--- a/Result.Test/ApiResultTest.cs
+++ b/Result.Test/ApiResultTest.cs
@@ -69,4 +69,19 @@ public class ApiResultTest
         objectResult.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
         objectResult.Value.Should().BeOfType<Exception>();
     }
+    
+    [Fact]
+    public void When_Result_Is_Error_And_Call_GetObjectResult_Should_Return_ObjectResult_With_Error_Message()
+    {
+        // Arrange
+        var result = ApiResult.ApiResult.Fail(StatusCodes.Status400BadRequest, "error");
+
+        // Act
+        var objectResult = result.GetObjectResult();
+
+        // Assert
+        objectResult.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        objectResult.Value.Should().BeOfType<string>();
+        objectResult.Value.Should().Be("error");
+    }
 }

--- a/Src/Result.Api/EmptyApiResult/ApiResult.cs
+++ b/Src/Result.Api/EmptyApiResult/ApiResult.cs
@@ -26,7 +26,7 @@ public class ApiResult : Result
     
     public ObjectResult GetObjectResult()
     {
-        return new ObjectResult(null)
+        return new ObjectResult(ErrorMessage)
         {
             StatusCode = StatusCode
         };
@@ -40,7 +40,7 @@ public class ApiResult : Result
 
     public IResult GetResult()
     {
-        return Results.Json(null , statusCode: StatusCode);
+        return Results.Json(ErrorMessage , statusCode: StatusCode);
     }
     
     public static implicit operator ObjectResult(ApiResult result)

--- a/Src/Result.Api/Result.Api.csproj
+++ b/Src/Result.Api/Result.Api.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
         <RootNamespace>Result</RootNamespace>
         <PackageId>Keyroll.ApiResult</PackageId>
-        <PackageVersion>0.7.3S</PackageVersion>
+        <PackageVersion>0.7.3</PackageVersion>
         <Title>ApiResult</Title>
         <Authors>Karol Kaźmierczak</Authors>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Src/Result.Api/Result.Api.csproj
+++ b/Src/Result.Api/Result.Api.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Version>0.7.2</Version>
+        <Version>0.7.3</Version>
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Result</RootNamespace>
         <PackageId>Keyroll.ApiResult</PackageId>
-        <PackageVersion>0.7.2</PackageVersion>
+        <PackageVersion>0.7.3S</PackageVersion>
         <Title>ApiResult</Title>
         <Authors>Karol Kaźmierczak</Authors>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Update project version from 0.7.2 to 0.7.3 in the csproj. Additionally, improve error handling in ApiResult by returning an error message instead of null. This change helps to better understand the problems that occurred during the execution of the API and aids in debugging process.