### PR TITLE
Update error handling in Result class and tests

### DIFF
--- a/Result.Test/ResultTests.cs
+++ b/Result.Test/ResultTests.cs
@@ -60,4 +60,16 @@ public class ResultTests
         resultSuccessModel.Should().BeNull();
         errorModel.Should().NotBeNull();
     }
+
+    [Fact]
+    public void When_Empty_Result_Is_Error_Then_Should_Keep_Error_Message()
+    {
+        // Act
+        var result = Result.Fail("error message");
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorModel.Should().Be("error message");
+        result.ErrorMessage.Should().Be("error message");
+    }
 }

--- a/Src/Result/EmptyResult/Result.cs
+++ b/Src/Result/EmptyResult/Result.cs
@@ -17,6 +17,6 @@ public class Result : Result<object, string>
 
     public static Result Fail(string? errorMessage = null)
     {
-        return new Result(false, string.Empty);
+        return new Result(false, errorMessage);
     }
 }

--- a/Src/Result/Result.csproj
+++ b/Src/Result/Result.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Version>0.7.1</Version>
+        <Version>0.7.2</Version>
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Result</RootNamespace>
         <PackageId>Keyroll.Result</PackageId>
-        <PackageVersion>0.7.1</PackageVersion>
+        <PackageVersion>0.7.2</PackageVersion>
         <Title>Result</Title>
         <Authors>Karol Kaźmierczak</Authors>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Updated Result.Fail method to return an error message instead of an empty string. This change lets the consumer of the Result class handle failures more appropriately and makes debug easier. Additionally, a new unit test was added to validate this behavior. Also, the version in Result.csproj was bumped to 0.7.2 in preparation for the new release.